### PR TITLE
feat: update package for cocoapods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
-.DS_Store
+**/*.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -10,29 +10,18 @@ let package = Package(
         .library(
             name: "FetchNodeDetails",
             targets: ["FetchNodeDetails"]),
-        .library(
-            name: "FndBase",
-            targets: ["FndBase"])
     ],
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
     ],
     targets: [
         .target(
-            name: "CommonSources",
-            dependencies: ["BigInt"],
-            path: "Sources/CommonSources"),
-        .target(
-            name: "FndBase",
-            dependencies: ["CommonSources"],
-            path: "Sources/FndBase"),
-        .target(
             name: "FetchNodeDetails",
-            dependencies: ["CommonSources", "FndBase"],
-            path: "Sources/FetchNodeDetails"),
+            dependencies: ["BigInt"],
+            path: "Sources"),
         .testTarget(
             name: "FetchNodeDetailsTests",
-            dependencies: ["FetchNodeDetails","CommonSources", "FndBase"]),
+            dependencies: ["FetchNodeDetails"]),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Sources/FetchNodeDetails/Constants/Constants.swift
+++ b/Sources/FetchNodeDetails/Constants/Constants.swift
@@ -1,5 +1,3 @@
-import CommonSources
-
 let TORUS_NETWORK: [TorusNetwork: String] = [
     TorusNetwork.sapphire(SapphireNetwork.SAPPHIRE_DEVNET) : "sapphire_devnet",
     TorusNetwork.sapphire(SapphireNetwork.SAPPHIRE_MAINNET) : "sapphire_mainnet",

--- a/Sources/FetchNodeDetails/NodeDetailManager.swift
+++ b/Sources/FetchNodeDetails/NodeDetailManager.swift
@@ -1,8 +1,6 @@
 import BigInt
 import Foundation
 import OSLog
-import CommonSources
-import FndBase
 // Global variable
 var fndLogType = OSLogType.default
 

--- a/Sources/FndBase/Configs/SapphireConfig.swift
+++ b/Sources/FndBase/Configs/SapphireConfig.swift
@@ -1,12 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by CW Lee on 10/07/2023.
-//
-
 import Foundation
-import CommonSources
 
 public var SapphireMainnetNodePub : [TorusNodePubModel] = [
     .init(_X: "e0925898fee0e9e941fdca7ee88deec99939ae9407e923535c4d4a3a3ff8b052", _Y: "54b9fea924e3f3e40791f9987f4234ae4222412d65b74068032fa5d8b63375c1"),

--- a/Sources/FndBase/Endpoints/Endpoints.swift
+++ b/Sources/FndBase/Endpoints/Endpoints.swift
@@ -1,5 +1,3 @@
-import CommonSources
-
 let SAPPHIRE_NETWORK_URLS: [SapphireNetwork: [String]] = [
     .SAPPHIRE_DEVNET: [
         "https://node-1.dev-node.web3auth.io",

--- a/Sources/FndBase/Utils/Utils.swift
+++ b/Sources/FndBase/Utils/Utils.swift
@@ -1,5 +1,3 @@
-import CommonSources
-
 public func fetchLocalConfig(network: TorusNetwork) throws -> AllNodeDetailsModel? {
     
     switch network {

--- a/Tests/FetchNodeDetailsTests/SampleOutput.swift
+++ b/Tests/FetchNodeDetailsTests/SampleOutput.swift
@@ -1,7 +1,5 @@
 import BigInt
-@testable import CommonSources
 @testable import FetchNodeDetails
-@testable import FndBase
 
 import XCTest
 

--- a/Tests/FetchNodeDetailsTests/fetchNodeDetailsTests.swift
+++ b/Tests/FetchNodeDetailsTests/fetchNodeDetailsTests.swift
@@ -1,5 +1,4 @@
 @testable import FetchNodeDetails
-import FndBase
 
 import XCTest
 

--- a/Torus-fetchNodeDetails.podspec
+++ b/Torus-fetchNodeDetails.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Torus-fetchNodeDetails"
-  spec.version      = "5.1.0"
+  spec.version      = "6.0.0"
   spec.ios.deployment_target = '13.0'
   spec.summary      = "Fetches the node details from torus nodelist smart contract"
   spec.homepage     = "https://github.com/torusresearch/fetch-node-details-swift"
@@ -8,10 +8,7 @@ Pod::Spec.new do |spec|
   spec.swift_version   = "5.3"
   spec.author       = { "Shubham Rathi" => "rathishubham017@gmail.com" }
   spec.source       = { :git => "https://github.com/torusresearch/fetch-node-details-swift.git", :tag => spec.version }
-  spec.source_files = "Sources/FetchNodeDetails/*.{swift,json}","Sources/FetchNodeDetails/**/*.{swift,json}"
-  spec.source_files = "Sources/FndBase/*.{swift,json}","Sources/FndBase/**/*.{swift,json}"
-  spec.source_files = "Sources/CommonSources/*.{swift,json}","Sources/CommonSources/**/*.{swift,json}"
+  spec.source_files = "Sources/**/*.{swift,json}"
   spec.module_name = "FetchNodeDetails"
   spec.dependency 'BigInt', '~> 5.2.0'
-
 end


### PR DESCRIPTION
Move modules fndbase and commonsources into parent module fetchnodedetails to limit the need to use @canimport of module followed by explicit import of parent  in packages using this one as a dependency.

Update podspec version to next major version.

Once merged the commit will need to be tagged 6.0.0